### PR TITLE
Add tests

### DIFF
--- a/.test/shrink-alpha-documents/Dockerfile
+++ b/.test/shrink-alpha-documents/Dockerfile
@@ -1,0 +1,3 @@
+FROM stencila/alpha
+COPY . .
+CMD bash cmd.sh

--- a/.test/shrink-alpha-documents/cmd.sh
+++ b/.test/shrink-alpha-documents/cmd.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+
+# Run a Stencila Host in the background and ignore startup message
+node -e "require('stencila-node').run()" > /dev/null &
+
+# Sleep for a bit to allow Host to startup before prodding it for execution contexts
+sleep 5
+
+# Execute a document using the above Host to provide execution contexts etc
+# In the future there will be no need to run separate processes jus something like:
+#    node -e "require('stencila-node').execute('document.md')" 
+STENCILA_PEERS=http://localhost:2000 node node_modules/stencila/tools/runner.js document.md

--- a/.test/shrink-alpha-documents/document.md
+++ b/.test/shrink-alpha-documents/document.md
@@ -1,0 +1,9 @@
+# Very simple document
+
+It would be interesting to have a number of documents in this test which make use of an increasing number of packages and then compare the shrinkage that we get from them (and of course whether we get the same digest!)
+
+```r
+#!
+data(mtcars)
+plot(disp~cyl,mtcars)
+```

--- a/.test/shrink-alpha-documents/test.sh
+++ b/.test/shrink-alpha-documents/test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+
+# Build the docker image
+docker build . --tag test-shrink-alpha-documents
+
+# Run it and do something with output
+docker run test-shrink-alpha-documents

--- a/.test/test.sh
+++ b/.test/test.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+cd shrink-alpha-documents && ./test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
 
 script:
   - ./.build/build.sh
-  - ./.test/test.sh
+  - cd .test && ./test.sh
 
 after_success:
   - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then ./.build/push.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_script:
 
 script:
   - ./.build/build.sh
+  - ./.test/test.sh
 
 after_success:
   - if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_EVENT_TYPE" == "cron" ]; then ./.build/push.sh; fi

--- a/alpha/Dockerfile
+++ b/alpha/Dockerfile
@@ -73,7 +73,7 @@ RUN Rscript -e "\
 
 # Install Stencila packages
 # Currently here near the end for easy updating during development
-RUN npm install stencila-node@0.27.0
+RUN npm install stencila-node@0.27-document-digest
 RUN pip install https://github.com/stencila/py/tarball/0.27.0
 RUN Rscript -e "devtools::install_github('stencila/r@0.27.0')"
 


### PR DESCRIPTION
@finlay and @hamishmack : here's an initial test setup. In the `stencila/stencila` repo I added a document digest to the `runner` tool. When you shrink the image you should get no errors and the same digest as with the full image.

With luck, this should run on Travis.

Feel free to merge in to master.