### PR TITLE
Avoid exporting all docker files to temp dir

### DIFF
--- a/.shrink/README.md
+++ b/.shrink/README.md
@@ -5,14 +5,24 @@ Usage: `shrink-docker.sh IN_IMAGE OUT_REPOSITORY[:TAG] COMMAND [ARG...]`
 Shrinks `IN_IMAGE` down to just the files needed to run `COMMAND` and
 saves result to `OUT_REPOISTORY`.
 
-In order to run `strace` a new image will be derived from `IN_IMAGE`
-with `strace` installed. This is installed with `apt-get`.
-
 If you need to specify other command line options for `docker run`,
 set the `DOCKER_FLAGS` environment variable.
 
+## Intermediate Images Created
+
+### `IN_IMAGE:strace` (or `IN_IAMGE:TAG-strace`)
+In order to run `strace` a new image will be derived from `IN_IMAGE`
+with `strace` installed. This is installed with `apt-get`.
+
+### `OUT_REPOSITORY:shrinking` (or `OUT_REPOSITORY:TAG-shrinking`)
+This image has all the unused files removed.
+The `OUT_REPOSITORY[:TAG]` is a flattened version of this image.
+
 ## macOS
-Not working yet.
+You may need to set the `SHRINK_TEMP` environment variable to point
+to a subdirectory of a directory in your File Sharing list in the
+Docker preferences.  The default location for temporary files in
+macOS is not in this list by default.
 
 ## Warnings
 
@@ -24,11 +34,3 @@ may require different files.
 Even the same command may fail if some part of it is
 nondeterministic (for instance if the set of files used from the
 original docker image depends on the current time).
-
-### Disk space usage
-To make the new image all the files in the existing image will be
-unpacked to a temporary working directory.  This will use a lot of disk space
-in your temporary directory (usually `/tmp`).  To create the working
-directory somewhere else set the `SHRINK_TEMP` environment variable
-to the parent directory you would like the working directory to be
-created in.


### PR DESCRIPTION
By doing the file removal in the docker container before exporting
we can simplify the export to just pipe directly to import.

This commit also resolves the issue with macOS.