### PR TITLE
Fix shrink-alpha-documents

### DIFF
--- a/.shrink/shrink-docker.sh
+++ b/.shrink/shrink-docker.sh
@@ -73,7 +73,7 @@ docker run --rm --cap-add SYS_PTRACE -v "$TEMPDIR":/mnt/strace $DOCKER_FLAGS $ST
 
 # Make a sorted list of the files we need to keep based on the strace output
 read -r -d '' READLINKS <<-'HERE' || true
-    KEEP=$(egrep '^[0-9]* *(access|open|execve|stat)\(\"' /mnt/strace/strace.out | sed 's/^[0-9]* *\(access\|open\|execve\|stat\)("\([^"]*\)".*$/\2/' | sort -u)
+    KEEP=$(egrep '^[0-9]* *([a-z0-9A-Z]*)\(\"' /mnt/strace/strace.out | sed 's/^[0-9]* *\([a-z0-9A-Z]*\)("\([^"]*\)".*$/\2/' | sort -u)
     while read -r k; do
       LAST=""
       TARGET="$k"
@@ -85,7 +85,7 @@ read -r -d '' READLINKS <<-'HERE' || true
     done <<< "$KEEP"
 HERE
 
-docker run --rm --user root -v "$TEMPDIR":/mnt/strace -w /mnt/strace/ $IN_IMAGE bash -c "$READLINKS" | sort -u > "$TEMPDIR"/keep.txt
+docker run --rm --user root -v "$TEMPDIR":/mnt/strace $IN_IMAGE bash -c "$READLINKS" | sort -u > "$TEMPDIR"/keep.txt
 
 # Make a sorted list of all the files in the image
 docker run --rm --user root -v "$TEMPDIR":/mnt/strace -w /mnt/strace/ $IN_IMAGE \
@@ -111,8 +111,7 @@ USER root
 
 COPY exclude.txt /
 RUN (cat /exclude.txt | grep -v "$(which rm)" | tr "\n" "\0" | xargs -0 rm -f | true) && \
-    rm /exclude.txt && \
-    rm "$(which rm)"
+    rm /exclude.txt
 
 USER $DOCKERUSER
 HERE

--- a/.test/shrink-alpha-documents/Dockerfile
+++ b/.test/shrink-alpha-documents/Dockerfile
@@ -1,3 +1,3 @@
 FROM stencila/alpha
-COPY . .
+COPY cmd.sh document.md ./
 CMD bash cmd.sh

--- a/.test/shrink-alpha-documents/cmd.sh
+++ b/.test/shrink-alpha-documents/cmd.sh
@@ -4,11 +4,12 @@
 node -e "require('stencila-node').run()" > /dev/null &
 
 # Sleep for a bit to allow Host to startup before prodding it for execution contexts
-sleep 2
+sleep 5
 
 # Execute a document using the above Host to provide execution contexts etc
 # In the future there will be no need to run separate processes jus something like:
 #    node -e "require('stencila-node').execute('document.md')" 
 STENCILA_PEERS=http://localhost:2000 node node_modules/stencila/tools/runner.js document.md
 
+sleep 50
 kill $(pgrep node)

--- a/.test/shrink-alpha-documents/test.sh
+++ b/.test/shrink-alpha-documents/test.sh
@@ -11,4 +11,4 @@ FULL=$(docker run test-shrink-alpha-documents)
 
 
 # Still not working 
-SHRINKED=$(docker run test-shrink-alpha-documents-shrinked bash cmd.sh)
+docker run --rm -w /home/guest -u guest -w /home/guest -u guest -e "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" -e "DEBIAN_FRONTEND=noninteractive" test-shrink-alpha-documents-shrinked bash cmd.sh


### PR DESCRIPTION
Fixes working dir issue by using the containers default (in this
case /home/guest).  If processes do cd we will need to track the
cwd on a per process basis.